### PR TITLE
friendly to python code

### DIFF
--- a/themes/Pale Fire-color-theme.json
+++ b/themes/Pale Fire-color-theme.json
@@ -236,7 +236,23 @@
 			"settings": {
 				"fontStyle": "underline"
 			}
-		}
+        },
+        {
+            "scope": "keyword.operator.logical.python",
+            "settings": {
+                "foreground": "#F0DFAF",
+                "fontStyle": "bold"
+            }
+        },
+        {
+            "scope": [
+                "meta.function-call.generic.python",
+                "source.python support"
+            ],
+            "settings": {
+                "foreground": "#93E0E3",
+            }
+        }
 	]
 }
 /*


### PR DESCRIPTION
Hi, thanks for your theme.  I love using it in vscode.

I'm also writing python code, and I think adding some configution for some syntax highlighting is helpful.  (This PR is mainly handled for python function call and logical operator).

Hope it can make some help :)