### PR TITLE
Add number, unit and character highlighting

### DIFF
--- a/themes/Pale Fire-color-theme.json
+++ b/themes/Pale Fire-color-theme.json
@@ -40,7 +40,7 @@
 			"foreground": "#DFAF8F",
 			"fontStyle": "italic"
 		},
-		"number": "#DCDCCC",
+		"number": "#BFEBBF",
 		"string": "#CC9393",
 		"attribute": "#94BFF3",
 		"function.attribute": "#94BFF3",
@@ -151,11 +151,12 @@
 		},
 		{
 			"scope": [
-				"constant.character",
-				"constant.numeric"
+				"constant.numeric",
+				"keyword.other.unit"
 			],
 			"settings": {
-				"foreground": "#DCDCCC"
+				"foreground": "#BFEBBF",
+				"fontStyle": ""
 			}
 		},
 		{
@@ -166,8 +167,11 @@
 			}
 		},
 		{
-			"name": "String",
-			"scope": "string",
+			"name": "String and Character",
+			"scope": [
+				"string",
+				"constant.character"
+			],
 			"settings": {
 				"foreground": "#CC9393",
 			}


### PR DESCRIPTION
I noticed that [you removed number and character highlighting](https://github.com/matklad/pale-fire/commit/92892fd915ea7f2bd083c533145b9e1ca9f1dc1e) previously, but I still think that it looks better with than without. Take this CSS as an example:

Before:
<img width="120" alt="Screen Shot 2020-07-14 at 11 53 40 pm" src="https://user-images.githubusercontent.com/31783266/87433950-3f891d80-c62d-11ea-8536-09580728f607.png">

After:
<img width="116" alt="Screen Shot 2020-07-14 at 11 53 19 pm" src="https://user-images.githubusercontent.com/31783266/87433909-339d5b80-c62d-11ea-8a5a-91b332e44320.png">

Note that these screenshots are without #5.

Since you removed this highlighting before, I completely understand if you reject this :)