### PR TITLE
Highlight null as a constant instead of as a keyword

### DIFF
--- a/themes/Pale Fire-color-theme.json
+++ b/themes/Pale Fire-color-theme.json
@@ -299,7 +299,6 @@
 		{
 			"name": "Keyword",
 			"scope": [
-				"constant.language.null",
 				"entity.name.tag",
 				"keyword.operator.expression",
 				"keyword.operator.new",


### PR DESCRIPTION
I put this as a PR because I think it’s highly subjective and want to make sure that you’re OK with the change.