### PR TITLE
Make properties green

### DIFF
--- a/themes/Pale Fire-color-theme.json
+++ b/themes/Pale Fire-color-theme.json
@@ -123,7 +123,7 @@
 		"*.unsafe": "#BC8383",
 		"function.unsafe": "#BC8383",
 		"operator.unsafe": "#BC8383",
-		"property": "#DFAF8F",
+		"property": "#AFD8AF",
 		"function": "#93E0E3",
 		"namespace": "#BFEBBF",
 		"macro": "#94BFF3",
@@ -163,7 +163,7 @@
 				"variable.other.property"
 			],
 			"settings": {
-				"foreground": "#DFAF8F",
+				"foreground": "#AFD8AF",
 			}
 		},
 		{


### PR DESCRIPTION
I’ve been writing some code with a lot of properties, and have found that the orange can be a bit overwhelming and can drown out the other colours:

<img width="1079" alt="Screen Shot 2020-07-23 at 10 17 15 pm" src="https://user-images.githubusercontent.com/31783266/88285794-0b9baf80-cd33-11ea-99e4-2023edc73a20.png">

Before properties were made orange, the only syntactical elements that were orange were lifetimes and type parameters. I think this was better, as it deservedly emphasised them more:

<img width="1079" alt="Screen Shot 2020-07-23 at 10 17 27 pm" src="https://user-images.githubusercontent.com/31783266/88285810-11919080-cd33-11ea-91c2-6f65b9f88557.png">

What do you think?