### PR TITLE
Highlight static variables the same as const ones

### DIFF
--- a/themes/Pale Fire-color-theme.json
+++ b/themes/Pale Fire-color-theme.json
@@ -138,6 +138,7 @@
 		"macro": "#94BFF3",
 		"formatSpecifier": "#94BFF3",
 		"variable": "#DCDCCC",
+		"variable.static": "#BDE0F3",
 		"variable.static.constant": "#BDE0F3",
 		"struct": "#7CB8BB",
 		"enum": "#7CB8BB",


### PR DESCRIPTION
I made this a PR because I thought it might be worth keeping them different to emphasise how `const`s get inlined while `static`s aren’t.