### PR TITLE
Utilise new `crateRoot` modifier from r-a

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -431,7 +431,7 @@ fn syntax_highlighting(builder: &mut ThemeBuilder, palette: &Palette) {
             Semantic("typeParameter"),
             Textmate("entity.name.type.parameter"),
         ],
-        palette.orange(0),
+        palette.orange(1),
     );
 
     builder.add_rules(
@@ -469,8 +469,10 @@ fn syntax_highlighting(builder: &mut ThemeBuilder, palette: &Palette) {
             Textmate("entity.name.type.module"),
             Textmate("variable.other.constant.elixir"),
         ],
-        palette.green(2),
+        palette.green(0),
     );
+
+    builder.add_rule(Semantic("namespace.crateRoot"), palette.green(2));
 
     builder.add_rules(
         &[

--- a/themes/Pale Fire High Contrast-color-theme.json
+++ b/themes/Pale Fire High Contrast-color-theme.json
@@ -238,7 +238,7 @@
 			"fontStyle": ""
 		},
 		"typeParameter": {
-			"foreground": "#E6B18E",
+			"foreground": "#F9C3A0",
 			"fontStyle": ""
 		},
 		"property": {
@@ -256,6 +256,10 @@
 			"italic": true
 		},
 		"namespace": {
+			"foreground": "#9FCC9F",
+			"fontStyle": ""
+		},
+		"namespace.crateRoot": {
 			"foreground": "#C3F1C3",
 			"fontStyle": ""
 		},
@@ -704,7 +708,7 @@
 		{
 			"scope": "entity.name.type.parameter",
 			"settings": {
-				"foreground": "#E6B18E",
+				"foreground": "#F9C3A0",
 				"fontStyle": ""
 			}
 		},
@@ -781,49 +785,49 @@
 		{
 			"scope": "entity.name.module",
 			"settings": {
-				"foreground": "#C3F1C3",
+				"foreground": "#9FCC9F",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "entity.name.namespace",
 			"settings": {
-				"foreground": "#C3F1C3",
+				"foreground": "#9FCC9F",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "entity.name.type.namespace",
 			"settings": {
-				"foreground": "#C3F1C3",
+				"foreground": "#9FCC9F",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "storage.modifier.import",
 			"settings": {
-				"foreground": "#C3F1C3",
+				"foreground": "#9FCC9F",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "storage.modifier.package",
 			"settings": {
-				"foreground": "#C3F1C3",
+				"foreground": "#9FCC9F",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "entity.name.type.module",
 			"settings": {
-				"foreground": "#C3F1C3",
+				"foreground": "#9FCC9F",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "variable.other.constant.elixir",
 			"settings": {
-				"foreground": "#C3F1C3",
+				"foreground": "#9FCC9F",
 				"fontStyle": ""
 			}
 		},

--- a/themes/Pale Fire-color-theme.json
+++ b/themes/Pale Fire-color-theme.json
@@ -238,7 +238,7 @@
 			"fontStyle": ""
 		},
 		"typeParameter": {
-			"foreground": "#DFB397",
+			"foreground": "#F0C3A6",
 			"fontStyle": ""
 		},
 		"property": {
@@ -256,6 +256,10 @@
 			"italic": true
 		},
 		"namespace": {
+			"foreground": "#A5C9A5",
+			"fontStyle": ""
+		},
+		"namespace.crateRoot": {
 			"foreground": "#C4EAC4",
 			"fontStyle": ""
 		},
@@ -704,7 +708,7 @@
 		{
 			"scope": "entity.name.type.parameter",
 			"settings": {
-				"foreground": "#DFB397",
+				"foreground": "#F0C3A6",
 				"fontStyle": ""
 			}
 		},
@@ -781,49 +785,49 @@
 		{
 			"scope": "entity.name.module",
 			"settings": {
-				"foreground": "#C4EAC4",
+				"foreground": "#A5C9A5",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "entity.name.namespace",
 			"settings": {
-				"foreground": "#C4EAC4",
+				"foreground": "#A5C9A5",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "entity.name.type.namespace",
 			"settings": {
-				"foreground": "#C4EAC4",
+				"foreground": "#A5C9A5",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "storage.modifier.import",
 			"settings": {
-				"foreground": "#C4EAC4",
+				"foreground": "#A5C9A5",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "storage.modifier.package",
 			"settings": {
-				"foreground": "#C4EAC4",
+				"foreground": "#A5C9A5",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "entity.name.type.module",
 			"settings": {
-				"foreground": "#C4EAC4",
+				"foreground": "#A5C9A5",
 				"fontStyle": ""
 			}
 		},
 		{
 			"scope": "variable.other.constant.elixir",
 			"settings": {
-				"foreground": "#C4EAC4",
+				"foreground": "#A5C9A5",
 				"fontStyle": ""
 			}
 		},


### PR DESCRIPTION
This commit also lightens type parameters to differentiate from struct fields.

> P.S. I'm participating in [Hacktoberfest 2021](https://hacktoberfest.digitalocean.com/). If this PR is up to standard and merged, I'd appreciate if the `hacktoberfest-accepted` label could be added. Thanks!